### PR TITLE
Changes due to changes in libamtrack/libraary added support for WASM

### DIFF
--- a/libamtrackForJs/Dockerfile
+++ b/libamtrackForJs/Dockerfile
@@ -3,49 +3,50 @@
 # Dockerfile at: https://github.com/trzecieu/emscripten-docker/blob/master/docker/trzeci/emscripten/Dockerfile
 # 'trzeci/emscripten' image is adviced by Emscripten's creators
 # https://kripken.github.io/emscripten-site/docs/compiling/Travis.html
-ARG EMSCRIPTEN_SDK=sdk-tag-1.38.18-64bit
+ARG EMSCRIPTEN_SDK=sdk-tag-1.38.21-64bit
 FROM trzeci/emscripten:${EMSCRIPTEN_SDK}
-
-WORKDIR /emsdk_portable/
-RUN emsdk install latest \
-&&  emsdk activate latest
 
 RUN apt-get update \
 &&  apt-get install -y git \ 
 &&  apt-get install -y wget
 
+#Cmake use $ENV{HOME}/gsl-latest/gsl
+ENV HOME /home/root
+ENV GSL_PATH $HOME/
+RUN mkdir $GSL_PATH
+
 # using clean source files of GSL to compile it to JavaScript
 # instead of debian debian source package
-RUN wget "https://ftp.gnu.org/gnu/gsl/gsl-latest.tar.gz" \
-&&  mkdir /gsl-latest \
-&&  tar -xzvf gsl-latest.tar.gz -C /gsl-latest \
-&&  mv /gsl-latest/** /gsl-latest/gsl 
-WORKDIR /gsl-latest/gsl/
-RUN /bin/bash -c "source /emsdk_portable/emsdk_env.sh && emconfigure ./configure" 
-RUN /bin/bash -c "source /emsdk_portable/emsdk_env.sh && emmake make"
+
+RUN cd $GSL_PATH \
+&&  wget "https://ftp.gnu.org/gnu/gsl/gsl-latest.tar.gz" \
+&&  mkdir $GSL_PATH/gsl-latest \
+&&  tar -xzf gsl-latest.tar.gz -C $GSL_PATH/gsl-latest \
+&&  mv $GSL_PATH/gsl-latest/** $GSL_PATH/gsl-latest/gsl \
+&&  rm -r $GSL_PATH/gsl-latest.tar.gz \
+&&  cd $GSL_PATH/gsl-latest/gsl/ \
+&&  /bin/bash -c "emconfigure ./configure" \
+&&  /bin/bash -c "emmake make"
 
 ARG repoUrl
 ARG branch
+ARG WASM
 
 WORKDIR /
 RUN git clone -b $branch $repoUrl 
-RUN rm /library/js/libgsl.a \
-&&  rm /library/js/libgsl.so \
-&&  cp /gsl-latest/gsl/.libs/libgsl.a /library/js/ \
-&&  cp /gsl-latest/gsl/.libs/libgsl.so /library/js/ 
+RUN cp ${GSL_PATH}/gsl-latest/gsl/.libs/libgsl.a /library/distributions/JavaScript/
 
-WORKDIR /library
+WORKDIR /library/distributions/JavaScript/
 RUN chmod +x compile_to_js.sh \
-&&  /bin/bash -c "./compile_to_js.sh" 
+&&  /bin/bash -c "./compile_to_js.sh $WASM" 
 
-RUN  cp /library/libat.js / \
-&&  cp /library/libat.wasm / \
-&&  apt-get -y remove \
-        wget \
-        git \
-&&  apt-get -y clean \
-&&  apt-get -y autoclean \
-&&  apt-get -y autoremove \
+RUN cp /library/distributions/JavaScript/output/libat.js / \
+&&  cp /library/distributions/JavaScript/output/libat.wasm / 2>/dev/null || : #ignore error when build with -s WASM=0 
+RUN apt-get -y remove \
+	           wget \
+		       git \
+&&  rm -rf /library \
+&&  rm -rf ${GSL_PATH}/gsl-latest/gsl/ \
 &&  echo "\nDone"
 
 WORKDIR /

--- a/libamtrackForJs/README.md
+++ b/libamtrackForJs/README.md
@@ -1,2 +1,31 @@
 # DockerFiles
 Dockerfile that creates image with compiled libamtrack core to JavaScript.
+
+Commands
+to build
+```
+docker-compose build
+```
+
+to build without using cache
+```
+docker-compose build --no-cache
+```
+
+to start container
+```
+docker-compose up
+```
+
+to inspect container
+```
+docker-compose exec libamtrack bash
+```
+
+copy compiled library to current directory ( need first docker-compose up)
+```
+docker cp libamtrack:/libat.js .
+docker cp libamtrack:/libat.wasm .
+```
+
+If you want to compile without WASM change in docker-compose.yml WASM to 0

--- a/libamtrackForJs/docker-compose.yml
+++ b/libamtrackForJs/docker-compose.yml
@@ -7,4 +7,5 @@ services:
    args:
     - repoUrl=https://github.com/libamtrack/library.git
     - branch=forjs
+    - WASM=1
   command: tail -f /dev/null


### PR DESCRIPTION
Changes:
- switched to newset version of trzeci/emscripten image
- removed emsdk install latest due to fixes in trzeci/emscripten [See](https://github.com/trzecieu/emscripten-docker/issues/34)
- statr using $HOME to keep gsl sources there 
- added WASM argument to enable compile to not-wasm version (libamtrack/web#86)
- extended README
- copy commads to get libat.js and libat.wasm to host in README