### PR TITLE
Extend travis to compile lib with and without wasm and create PR in web repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,10 @@ after_success:
   - sudo git add -A
   - sudo git commit -m "Update compiled library"
   - sudo git push "https://marwin1991:$GH_TOKEN@github.com/libamtrack/web.git"
+
+
+  # install hub tool and create pull request in web repo
+  - cd /
+  - sudo wget https://github.com/github/hub/releases/download/v2.7.0/hub-linux-arm64-2.7.0.tgz
+  - sudo tar -xzf hub-linux-arm64-2.7.0.tgz -C /hub
+  - ls /hub 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,4 @@ after_success:
   # install hub tool and create pull request in web repo
   - cd /
   - sudo wget https://github.com/github/hub/releases/download/v2.7.0/hub-linux-arm64-2.7.0.tgz
-  - sudo tar -xzf hub-linux-arm64-2.7.0.tgz -C /hub
-  - ls /hub 
+  - sudo tar -xzf hub-linux-arm64-2.7.0.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ script:
   # compile with WASM support
   - docker build --build-arg repoUrl=https://github.com/libamtrack/library.git --build-arg branch=forjs --build-arg WASM=1 -t libamtrack/libamtrackforjs:latest .
   - docker run -itd --name libamtrack libamtrack/libamtrackforjs
-  - docker cp libamtrack:/libat.js /compiled
-  - docker cp libamtrack:/libat.wasm /compiled
+  - sudo docker cp libamtrack:/libat.js /compiled
+  - sudo docker cp libamtrack:/libat.wasm /compiled
   - docker container rm -f libamtrack
   - docker image rm -f libamtrackforjs_libamtrack
 
@@ -22,7 +22,7 @@ script:
   - docker build --build-arg repoUrl=https://github.com/libamtrack/library.git --build-arg branch=forjs --build-arg WASM=0 -t libamtrack/libamtrackforjs:latest .
   - docker run -itd --name libamtrack libamtrack/libamtrackforjs
   - docker cp libamtrack:/libat.js .
-  - cp libat.js /compiled/libatwithoutwasm.js
+  - sudo cp libat.js /compiled/libatwithoutwasm.js
 
 on_success:
   # push new versions of compiled libraries

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,19 +27,19 @@ script:
 after_success:
   # push new versions of compiled libraries
   - cd /
-  - git clone https://github.com/libamtrack/web.git
+  - sudo git clone https://github.com/libamtrack/web.git
   - cd /web
   - current_date_time="`date "+%Y%m%d_%H%M%S"`"
   - git checkout -b "feature/compiled_lib/$current_date_time"
 
-  - rm -f /web/src/libat.wasm
-  - cp /compiled/libat.wasm /web/src/libat.wasm
+  - sudo rm -f /web/src/libat.wasm
+  - sudo cp /compiled/libat.wasm /web/src/libat.wasm
 
-  - rm -f /web/src/static/js/libat.js
-  - cp /compiled/libat.js /web/src/static/js/libat.js
+  - sudo rm -f /web/src/static/js/libat.js
+  - sudo cp /compiled/libat.js /web/src/static/js/libat.js
 
-  - rm -f /web/src/static/js/libatwithoutwasm.js
-  - cp /compiled/libatwithoutwasm.js /web/src/static/js/libatwithoutwasm.js
+  - sudo rm -f /web/src/static/js/libatwithoutwasm.js
+  - sudo cp /compiled/libatwithoutwasm.js /web/src/static/js/libatwithoutwasm.js
 
   - git add -A
   - git commit -m "Update compiled library"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,11 @@ after_success:
 
   # install hub tool and create pull request in web repo
   - cd /
-  - sudo wget https://github.com/github/hub/releases/download/v2.7.0/hub-linux-arm64-2.7.0.tgz
-  - sudo tar -xzf hub-linux-arm64-2.7.0.tgz
+  - sudo wget https://github.com/github/hub/releases/download/v2.7.0/hub-linux-amd64-2.7.0.tgz
+  - sudo tar -xzf hub-linux-amd64-2.7.0
   - GITHUB_TOKEN="$GH_TOKEN"
   - GITHUB_USER=marwin1991
-  - chmod +x /hub-linux-arm64-2.7.0/bin/hub
+  - chmod +x /hub-linux-amd64-2.7.0/bin/hub
   - cd /web
-  - /hub-linux-arm64-2.7.0/bin/./hub pull-request -m "New verions of compiled libamtrack library to JavaScipr with and witout WebAssembly"
+  - ls /hub-linux-amd64-2.7.0/bin/
+  - /hub-linux-amd64-2.7.0/bin/./hub pull-request -m "New verions of compiled libamtrack library to JavaScipr with and witout WebAssembly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ after_success:
   - cd /
   - sudo wget https://github.com/github/hub/releases/download/v2.7.0/hub-linux-amd64-2.7.0.tgz
   - sudo tar -xzf hub-linux-amd64-2.7.0.tgz
-  - GITHUB_TOKEN="$GH_TOKEN"
+  - export GITHUB_TOKEN="$GH_TOKEN"
   - chmod +x /hub-linux-amd64-2.7.0/bin/hub
   - cd /web
   - ls /hub-linux-amd64-2.7.0/bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 before_script:
   - docker --version
 script:
-  - mkdir /compiled # directory to store compiled library
+  - sudo mkdir /compiled # directory to store compiled library
   - cd libamtrackForJs
 
   # compile with WASM support

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ after_success:
   - sudo git clone https://github.com/libamtrack/web.git
   - cd /web
   - current_date_time="`date "+%Y%m%d_%H%M%S"`"
-  - git checkout -b "feature/compiled_lib/$current_date_time"
+  - sudo git checkout -b "feature/compiled_lib/$current_date_time"
 
   - sudo rm -f /web/src/libat.wasm
   - sudo cp /compiled/libat.wasm /web/src/libat.wasm
@@ -41,6 +41,6 @@ after_success:
   - sudo rm -f /web/src/static/js/libatwithoutwasm.js
   - sudo cp /compiled/libatwithoutwasm.js /web/src/static/js/libatwithoutwasm.js
 
-  - git add -A
-  - git commit -m "Update compiled library"
-  - git push "https://marwin1991:$GH_TOKEN@github.com/libamtrack/web.git"
+  - sudo git add -A
+  - sudo git commit -m "Update compiled library"
+  - sudo git push "https://marwin1991:$GH_TOKEN@github.com/libamtrack/web.git"

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,8 @@ after_success:
   - cd /
   - sudo wget https://github.com/github/hub/releases/download/v2.7.0/hub-linux-arm64-2.7.0.tgz
   - sudo tar -xzf hub-linux-arm64-2.7.0.tgz
+  - GITHUB_TOKEN="$GH_TOKEN"
+  - GITHUB_USER=marwin1991
+  - chmod +x /hub-linux-arm64-2.7.0/bin/hub
+  - cd /web
+  - /hub-linux-arm64-2.7.0/bin/./hub pull-request -m "New verions of compiled libamtrack library to JavaScipr with and witout WebAssembly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,40 @@ services:
 before_script:
   - docker --version
 script:
+  - mkdir /compiled # directory to store compiled library
   - cd libamtrackForJs
-  - docker-compose build
-# - if build form other branch or from fork changes params below and use it or in docker-compose.yml
-# - docker build --build-arg repoUrl=https://github.com/libamtrack/library.git --build-arg branch=forjs .
+
+  # compile with WASM support
+  - docker build --build-arg repoUrl=https://github.com/libamtrack/library.git --build-arg branch=forjs --build-arg WASM=1 -t libamtrack/libamtrackforjs:latest .
+  - docker run -itd --name libamtrack libamtrack/libamtrackforjs
+  - docker cp libamtrack:/libat.js /compiled
+  - docker cp libamtrack:/libat.wasm /compiled
+  - docker container rm -f libamtrack
+  - docker image rm -f libamtrackforjs_libamtrack
+
+  # compile without WASM support
+  - docker build --build-arg repoUrl=https://github.com/libamtrack/library.git --build-arg branch=forjs --build-arg WASM=0 -t libamtrack/libamtrackforjs:latest .
+  - docker run -itd --name libamtrack libamtrack/libamtrackforjs
+  - docker cp libamtrack:/libat.js .
+  - cp libat.js /compiled/libatwithoutwasm.js
+
+on_success:
+  # push new versions of compiled libraries
+  - cd /
+  - git clone https://github.com/libamtrack/web.git
+  - cd /web
+  - current_date_time="`date "+%Y%m%d_%H%M%S"`"
+  - git checkout -b "feature/compiled_lib/$current_date_time"
+
+  - rm -f /web/src/libat.wasm
+  - cp /compiled/libat.wasm /web/src/libat.wasm
+
+  - rm -f /web/src/static/js/libat.js
+  - cp /compiled/libat.js /web/src/static/js/libat.js
+
+  - rm -f /web/src/static/js/libatwithoutwasm.js
+  - cp /compiled/libatwithoutwasm.js /web/src/static/js/libatwithoutwasm.js
+
+  - git add -A
+  - git commit -m "Update compiled library"
+  - git push "https://marwin1991:$GH_TOKEN@github.com/libamtrack/web.git"

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ after_success:
   # install hub tool and create pull request in web repo
   - cd /
   - sudo wget https://github.com/github/hub/releases/download/v2.7.0/hub-linux-amd64-2.7.0.tgz
-  - sudo tar -xzf hub-linux-amd64-2.7.0
+  - sudo tar -xzf hub-linux-amd64-2.7.0.tgz
   - GITHUB_TOKEN="$GH_TOKEN"
   - GITHUB_USER=marwin1991
   - chmod +x /hub-linux-amd64-2.7.0/bin/hub

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ after_success:
   - sudo wget https://github.com/github/hub/releases/download/v2.7.0/hub-linux-amd64-2.7.0.tgz
   - sudo tar -xzf hub-linux-amd64-2.7.0.tgz
   - GITHUB_TOKEN="$GH_TOKEN"
-  - GITHUB_USER=marwin1991
   - chmod +x /hub-linux-amd64-2.7.0/bin/hub
   - cd /web
   - ls /hub-linux-amd64-2.7.0/bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - docker cp libamtrack:/libat.js .
   - sudo cp libat.js /compiled/libatwithoutwasm.js
 
-on_success:
+after_success:
   # push new versions of compiled libraries
   - cd /
   - git clone https://github.com/libamtrack/web.git


### PR DESCRIPTION
I tried to use some travis build in mechanism to commit changes but I found only to add adtifacts to realse.
To create pull reqest from command line I've used [hub](https://github.com/github/hub), it is shame that they it can't be installed from apt-get.
I am thinking about limiting the part of createing branch, commit and pull reqest but for now i dont have any nice idea, I want to prevent from createing too much pull-request when there is no changes. I did not tested how it will work when git will try commit no-changes because library won't change.